### PR TITLE
Add --force-yes switch to make apt happy on Debian 8.2

### DIFF
--- a/parrot-install.sh
+++ b/parrot-install.sh
@@ -34,30 +34,30 @@ function core_install() {
 	#echo -e "deb http://eu.archive.parrotsec.org/mirrors/debian jessie main contrib non-free\n#deb-src http://eu.archive.parrotsec.org/mirrors/debian jessie main contrib non-free\n\n#deb http://eu.archive.parrotsec.org/mirrors/debian jessie-backports main contrib non-free\n#deb-src http://eu.archive.parrotsec.org/mirrors/debian jessie-backports main contrib non-free\n\ndeb http://security.debian.org/ jessie/updates main\n#deb-src http://security.debian.org/ jessie/updates main\n\ndeb http://eu.archive.parrotsec.org/mirrors/debian jessie-updates main contrib non-free\n#deb-src http://eu.archive.parrotsec.org/mirrors/debian jessie-updates main contrib non-free\n\n#deb http://eu.archive.parrotsec.org/mirrors/debian jessie-proposed-updates main contrib non-free\n#deb-src http://eu.archive.parrotsec.org/mirrors/debian jessie-updates main contrib non-free" > /etc/apt/sources.list.d/debian.list
 	wget -qO - http://archive.parrotsec.org/parrot/misc/parrotsec.gpg | apt-key add -
 	apt-get update
-	apt-get -y install apt-parrot parrot-archive-keyring --no-install-recommends
+	apt-get -y --force-yes install apt-parrot parrot-archive-keyring --no-install-recommends
 	apt-get update
-	apt-get -y install parrot-core
-	apt-get -y dist-upgrade
+	apt-get -y --force-yes install parrot-core
+	apt-get -y --force-yes dist-upgrade
 }
 
 function cloud_install() {
-	apt-get -y install parrot-cloud parrot-tools-cloud
+	apt-get -y --force-yes install parrot-cloud parrot-tools-cloud
 }
 
 function standard_install() {
-	apt-get -y install parrot-interface parrot-tools
+	apt-get -y --force-yes install parrot-interface parrot-tools
 }
 
 function full_install() {
-	apt-get -y install parrot-interface parrot-tools parrot-interface-full parrot-tools-full
+	apt-get -y --force-yes install parrot-interface parrot-tools parrot-interface-full parrot-tools-full
 }
 
 function home_install() {
-	apt-get -y install parrot-interface-full
+	apt-get -y --force-yes install parrot-interface-full
 }
 
 function embedded_install() {
-	apt-get -y install parrot-interface parrot-tools-arm
+	apt-get -y --force-yes install parrot-interface parrot-tools-arm
 }
 
 


### PR DESCRIPTION
For some reason, when I run the cloud install script on Debian 8.2 it complains that the -y switch is used without --force-yes and refuses to install. 

By adding --force-yes it makes the script work, but will assume any questions asked by apt itself should be answered with a yes. In the case of additional information needed by packages (i.e. service restarts, locale selection and others) it will still ask the user for an answer. Since this script is typically run on a fresh OS install (at least I would assume so) this change should be harmless.

Let me know if you have any questions!