### PR TITLE
Update parrot-install.sh

### DIFF
--- a/parrot-install.sh
+++ b/parrot-install.sh
@@ -30,7 +30,10 @@ function option_picked() {
 
 
 function core_install() {
-	echo -e "deb http://mirrordirector.archive.parrotsec.org/parrot parrot main contrib non-free" > /etc/apt/sources.list.d/parrot.list
+	# Protect against HTTP vulnerabilities [https://www.debian.org/security/2016/dsa-3733], [https://www.debian.org/security/2019/dsa-4371]
+	apt-get update
+	apt-get -y install apt-transport-https
+	echo -e "deb https://mirrordirector.archive.parrotsec.org/parrot parrot main contrib non-free" > /etc/apt/sources.list.d/parrot.list
 	echo -e "# This file is empty, feel free to add here your custom APT repositories\n\n# The standard Parrot repositories are NOT here. If you want to\n# edit them, take a look into\n#                      /etc/apt/sources.list.d/parrot.list\n#                      /etc/apt/sources.list.d/debian.list\n\n\n\n# If you want to change the default parrot repositories setting\n# another localized mirror, then use the command parrot-mirror-selector\n# and see its usage message to know what mirrors are available\n\n\n\n#uncomment the following line to enable the Parrot Testing Repository\n#deb http://us.repository.frozenbox.org/parrot testing main contrib nonfree" > /etc/apt/sources.list
 	wget -qO - https://archive.parrotsec.org/parrot/misc/parrotsec.gpg | apt-key add -
 	apt-get update


### PR DESCRIPTION
Use HTTPS mirror to prevent abuse of the following bugs:
- https://www.debian.org/security/2016/dsa-3733
- https://www.debian.org/security/2019/dsa-4371